### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/cite-datasets.bib
+++ b/cite-datasets.bib
@@ -40,7 +40,7 @@ MA},
   pages = {iii-iv},
   nameaddon = {(AAA-1019-2010)},
   timestamp = {2011-06-02},
-  url = {http://dx.doi.org/10.1023/B:MYCO.0000020677.89178.15}
+  url = {https://doi.org/10.1023/B:MYCO.0000020677.89178.15}
 }
 
 @ARTICLE{chavan.ingwersen2009tdp,

--- a/fig-doi.html
+++ b/fig-doi.html
@@ -1,7 +1,7 @@
 <table cellpadding="0" cellspacing="1" style="margin-right: auto; margin-left: auto; border-collapse: separate;">
 <tbody>
 <tr>
-<td style="border: currentColor; text-align: center; color: gray; font-size: 180%; background-color: white;">http://dx.doi.org/</td>
+<td style="border: currentColor; text-align: center; color: gray; font-size: 180%; background-color: white;">https://doi.org/</td>
 <td style="border: currentColor; text-align: center; font-size: 180%;">10.5284</td>
 <td style="border: currentColor; text-align: center; font-size: 180%;">/</td>
 <td style="border: currentColor; text-align: center; font-size: 180%;">1000389</td>

--- a/fig-doi.tex
+++ b/fig-doi.tex
@@ -1,6 +1,6 @@
 \centering
 \begin{tabular}{c@{\,}c@{\,}c@{\,}c}
-\Large$\underbrace{\textsf{\color{gray}{http://dx.doi.org/}}}$
+\Large$\underbrace{\textsf{\color{gray}{https://doi.org/}}}$
 & \Large$\underbrace{10\textsf{.}5284}$ 
 & \Large / 
 & \Large$\underbrace{1000389}$ \\

--- a/fig-html5.html
+++ b/fig-html5.html
@@ -1,8 +1,8 @@
 <pre style="color: rgb(216, 5, 5); background-color: white;">
 &lt;p <span style="color: rgb(47, 72, 158);">itemscope
-   itemid=&quot;</span><span style="color: rgb(116, 144, 57);">http://dx.doi.org/10.9876/data123</span><span style="color: rgb(47, 72, 158);">&quot;</span>&gt;
+   itemid=&quot;</span><span style="color: rgb(116, 144, 57);">https://doi.org/10.9876/data123</span><span style="color: rgb(47, 72, 158);">&quot;</span>&gt;
   <span style="color: rgb(0, 0, 0);">Supplement to: Author, A. (2011). ... </span>&lt;a
-  <span style="color: rgb(47, 72, 158);">href=&quot;</span><span style="color: rgb(116, 144, 57);">http://dx.doi.org/10.123/paper45</span><span style="color: rgb(47, 72, 158);">&quot;
+  <span style="color: rgb(47, 72, 158);">href=&quot;</span><span style="color: rgb(116, 144, 57);">https://doi.org/10.123/paper45</span><span style="color: rgb(47, 72, 158);">&quot;
   itemprop=&quot;</span><span style="color: rgb(116, 144, 57);">http://purl.org/spar/cito/
   providesDataFor</span><span style="color: rgb(47, 72, 158);">&quot;</span>&gt;<span style="color: rgb(0, 0, 0);">doi:10.123/paper45</span>&lt;/a&gt;
 &lt;/p&gt;

--- a/fig-html5.tex
+++ b/fig-html5.tex
@@ -1,10 +1,10 @@
 \raggedright\small\bgroup\ttfamily\frenchspacing
 <p \textcolor{dccblue}{itemscope\\~~~itemid="}%
-\textcolor{Green}{http://dx.doi.org/10.9876/data123}%
+\textcolor{Green}{https://doi.org/10.9876/data123}%
 \textcolor{dccblue}{"}>\\~~%
 \textcolor{black}{Supplement to: Author, A. (2011). ... }<a\\~~%
 \textcolor{dccblue}{href="}%
-\textcolor{Green}{http://dx.doi.org/10.123/paper45}%
+\textcolor{Green}{https://doi.org/10.123/paper45}%
 \textcolor{dccblue}{"\\~~itemprop="}%
 \textcolor{Green}{http://purl.org/spar/cito/\\~~providesDataFor}%
 \textcolor{dccblue}{"}%

--- a/fig-rdfa.html
+++ b/fig-rdfa.html
@@ -6,7 +6,7 @@
 <span style="color: rgb(0, 0, 0);">...</span>
 &lt;p&gt;
   <span style="color: rgb(0, 0, 0);">Supplement to: Author, A. (2011). ... </span>&lt;a
-  <span style="color: rgb(47, 72, 158);">about=&quot;</span><span style="color: rgb(116, 144, 57);">http://dx.doi.org/10.9876/data123</span><span style="color: rgb(47, 72, 158);">&quot;
+  <span style="color: rgb(47, 72, 158);">about=&quot;</span><span style="color: rgb(116, 144, 57);">https://doi.org/10.9876/data123</span><span style="color: rgb(47, 72, 158);">&quot;
   rel=&quot;</span><span style="color: rgb(116, 144, 57);">cito:providesDataFor</span><span style="color: rgb(47, 72, 158);">&quot; href=&quot;</span><span style="color: rgb(116, 144, 57);">http://dx
   .doi.org/10.123/paper45</span><span style="color: rgb(47, 72, 158);">&quot;</span>&gt;<span style="color: rgb(0, 0, 0);">doi:10.123/paper45</span>&lt;/a&gt;
 &lt;/p&gt;

--- a/fig-rdfa.tex
+++ b/fig-rdfa.tex
@@ -11,7 +11,7 @@
 \textcolor{black}{...}\\
 <p>\\~~\textcolor{black}{Supplement to: Author, A. (2011). ... }<a\\~~%
 \textcolor{dccblue}{about="}%
-\textcolor{Green}{http://dx.doi.org/10.9876/data123}%
+\textcolor{Green}{https://doi.org/10.9876/data123}%
 \textcolor{dccblue}{"\\~~rel="}%
 \textcolor{Green}{cito:providesDataFor}%
 \textcolor{dccblue}{" href="}%

--- a/how-to-cite-datasets.md
+++ b/how-to-cite-datasets.md
@@ -278,29 +278,29 @@ APA
 
   : Cool, H. E. M., & Bell, M. (2011). *Excavations at St Peter's Church,
     Barton-upon-Humber* \[Data set\].
-    [doi:10.5284/1000389](http://dx.doi.org/10.5284/1000389)
+    [doi:10.5284/1000389](https://doi.org/10.5284/1000389)
 
 Chicago
 
   : *(Footnote)* H. E. M. Cool and Mark Bell, Excavations at St Peter's Church,
     Barton-upon-Humber (accessed May 1, 2011),
-    [doi:10.5284/1000389](http://dx.doi.org/10.5284/1000389).
+    [doi:10.5284/1000389](https://doi.org/10.5284/1000389).
 
     *(Bibliography)* Cool, H. E. M., and Mark Bell. Excavations at St Peter's Church,
     Barton-upon-Humber (accessed May 1, 2011).
-    [doi:10.5284/1000389](http://dx.doi.org/10.5284/1000389).
+    [doi:10.5284/1000389](https://doi.org/10.5284/1000389).
 
 MLA
 
   : Cool, H. E. M., and Mark Bell. "Excavations at St Peter's Church,
     Barton-upon-Humber." Archaeology Data Service, 2001. Web. 1 May 2011.
-    `<`<http://dx.doi.org/10.5284/1000389>`>`.
+    `<`<https://doi.org/10.5284/1000389>`>`.
 
 Oxford
 
   : Cool, H. E. M. and Bell, M. (2011), *Excavations at St Peter's Church,
     Barton-upon-Humber* \[dataset\] (York: Archaeology Data Service),
-    doi: [10.5284/1000389](http://dx.doi.org/10.5284/1000389)
+    doi: [10.5284/1000389](https://doi.org/10.5284/1000389)
 
 \endshaded
 
@@ -315,14 +315,14 @@ PANGAEA
 
   : Willmes, S et al. (2009): Onset dates of annual snowmelt on Antarctic
     sea ice in 2007/2008.
-    [doi:10.1594/PANGAEA.701380](http://dx.doi.org/10.1594/PANGAEA.701380)
+    [doi:10.1594/PANGAEA.701380](https://doi.org/10.1594/PANGAEA.701380)
 
 Dryad
 
   : Kingsolver JG, Hoekstra HE, Hoekstra JM, Berrigan D, Vignieri SN,
     Hill CE, Hoang A, Gibert P, Beerli P (2001) Data from: The strength of
     phenotypic selection in natural populations. Dryad Digital Repository.
-    [doi:10.5061/dryad.166](http://dx.doi.org/10.5061/dryad.166)
+    [doi:10.5061/dryad.166](https://doi.org/10.5061/dryad.166)
 
 Dataverse
 
@@ -368,7 +368,7 @@ in a DOI have no special significance.
 While there are several services available that can resolve a DOI to an
 Internet location,^[Some publishers provide resolvers for their own DOIs, while
 the Handle resolver <http://hdl.handle.net/> can be used for any DOI.] the
-preferred one is <http://dx.doi.org/>. Appending a DOI to this URL creates a
+preferred one is <https://doi.org/>. Appending a DOI to this URL creates a
 further URL that can be used to access the associated resource. Authors are
 encouraged to use the URL version of the DOI wherever possible, though some
 publishers prefer to print the bare DOI and embed the URL form as a hyperlink
@@ -879,9 +879,9 @@ This can be done using RDFa Lite as in [Figure 4](#fig:rdfa)
 
 ~~~ {.html}
 <body vocab="http://purl.org/spar/cito/"> ...
-<p resource="http://dx.doi.org/10.9876/data123">
+<p resource="https://doi.org/10.9876/data123">
   Supplement to: Author, A. (2011). ...
-  <a href="http://dx.doi.org/10.123/paper45"
+  <a href="https://doi.org/10.123/paper45"
   property="providesDataFor">doi:10.123/paper45
   </a>
 </p> ...
@@ -948,7 +948,7 @@ is shown in [Figure 5](#fig:jats).
   <source>FigShare</source>,
   <date-in-citation content-type='pub-date' iso-8601-date='2014-06-30'>
     <day>30</day><month>06</month><year>2014</year></date-in-citation>,
-  <pub-id pub-id-type='doi' xlink:href='http://dx.doi.org/10.6084/m9.figshare.1088363'
+  <pub-id pub-id-type='doi' xlink:href='https://doi.org/10.6084/m9.figshare.1088363'
     assigning-authority='figshare'>10.6084/m9.figshare.1088363</pub-id>.
 </mixed-citation>
 ~~~


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!